### PR TITLE
Fix for incorrect text positioning on sequential redraws.

### DIFF
--- a/Classes/SMFancyText.m
+++ b/Classes/SMFancyText.m
@@ -40,6 +40,8 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 }
 
 - (void)drawRect:(CGRect)rect {
+
+	_currentPosition = CGPointMake(0, 0);
 	
 	CGContextRef graphicsContext = UIGraphicsGetCurrentContext();
 	


### PR DESCRIPTION
Fixed issue where redrawing the fancy text view resulted in it
appearing below the location where the text was previously drawn.
