### PR TITLE
Bugfixes and code improvements.

### DIFF
--- a/Classes/SMFancyText.h
+++ b/Classes/SMFancyText.h
@@ -20,7 +20,6 @@
 
 @interface SMFancyText : UIView {
 @private
-	htmlParserCtxtPtr _context;
 	CGPoint _currentPosition;
 }
 

--- a/Classes/SMFancyText.h
+++ b/Classes/SMFancyText.h
@@ -18,10 +18,7 @@
 
 @end
 
-@interface SMFancyText : UIView {
-@private
-	CGPoint _currentPosition;
-}
+@interface SMFancyText : UIView
 
 @property (nonatomic, retain) UIColor *textColor;
 @property (nonatomic, assign) id <SMFancyTextDelegate> delegate;

--- a/Classes/SMFancyText.m
+++ b/Classes/SMFancyText.m
@@ -190,7 +190,7 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 		point.x = 0;
 	}
 
-	CGRect theRect = CGRectMake(point.x, point.y, size.width, size.height);
+	CGRect frame = CGRectMake(point.x, point.y, size.width, size.height);
 
 	if (link || image) {
 		CGContextRef context = UIGraphicsGetCurrentContext();
@@ -201,7 +201,7 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 					
 					[self appendLinkWithText:string
 									 andLink:link
-								   withFrame:theRect
+								   withFrame:frame
 									 andFont:font
 									 atPoint:point
 								   inContext:context];
@@ -217,7 +217,7 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 				break;
 		}
 	} else {
-		[string drawInRect:theRect withFont:font];
+		[string drawInRect:frame withFont:font];
 	}
 
 	return CGPointMake(point.x + size.width, point.y);

--- a/Classes/SMFancyText.m
+++ b/Classes/SMFancyText.m
@@ -207,7 +207,7 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 
 	for (NSInteger i = 0; i < string.length; ++i) {
 		if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[mutableString characterAtIndex:i]]) {
-			whitespaceCount = i;
+			whitespaceCount = i + 1;
 		} else {
 			break;
 		}

--- a/Classes/SMFancyText.m
+++ b/Classes/SMFancyText.m
@@ -9,7 +9,11 @@
 #import "SMFancyText.h"
 #import "SMFancyTextElement.h"
 
-#define HTMLBullet @"•"
+static NSString * const SMHTMLBullet = @"•";
+const CGFloat SMFontSize = 14.0f;
+const CGFloat SMLinkRed = 65.0f;
+const CGFloat SMLinkGreen = 123.0f;
+const CGFloat SMLinkBlue = 192.0f;
 
 #pragma mark - LibXML Headers
 
@@ -45,49 +49,55 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 	
 	CGContextRef graphicsContext = UIGraphicsGetCurrentContext();
 	
-	if (self.textColor == nil) {
-		self.textColor = [UIColor blackColor];
-	}
+	if (!self.textColor) self.textColor = [UIColor blackColor];
 	
 	CGContextSetFillColorWithColor(graphicsContext, [self.textColor CGColor]);
 	
-    for (NSUInteger i = 0; i < [self.elements count]; ++i) {
+    for (SMFancyTextElement *element in self.elements) {
+
 		UIFont *font = nil;
 		
-		switch ((SMFancyTextElementStyle)[[self.elements objectAtIndex:i] style]) {
+		switch (element.style) {
 			case SMFancyTextElementStyleBold:
 			case SMFancyTextElementStyleBlockQuote:
-				font = [UIFont boldSystemFontOfSize:14.0];
+				font = [UIFont boldSystemFontOfSize:SMFontSize];
 				break;
 			case SMFancyTextElementStyleItalic:
-				font = [UIFont italicSystemFontOfSize:14.0];
+				font = [UIFont italicSystemFontOfSize:SMFontSize];
 				break;
 			default:
-				font = [UIFont systemFontOfSize:14.0];
+				font = [UIFont systemFontOfSize:SMFontSize];
 				break;
 		}
 		
-		if ([[self.elements objectAtIndex:i] style] == SMFancyTextElementStyleBlockQuote) {
+		if (element.style == SMFancyTextElementStyleBlockQuote) {
 			CGContextFillRect(graphicsContext, CGRectMake(0, _currentPosition.y - 5, rect.size.width, 2));
 		}
 
-		if ([[self.elements objectAtIndex:i] style] == SMFancyTextElementStyleParagraphBreak) {
+		if (element.style == SMFancyTextElementStyleParagraphBreak) {
 			_currentPosition.x = 0;
 			_currentPosition.y = _currentPosition.y + (18 * 2);
-		} else if ([[self.elements objectAtIndex:i] style] == SMFancyTextElementStyleNewLine) {
+		} else if (element.style == SMFancyTextElementStyleNewLine) {
 			_currentPosition.x = 0;
 			_currentPosition.y = _currentPosition.y + 18;
 		} else {
-			[self drawString:[[self.elements objectAtIndex:i] text] withFont:font atPoint:_currentPosition inRect:rect recursive:YES style:(SMFancyTextElementStyle)[[self.elements objectAtIndex:i] style] withLink:[[self.elements objectAtIndex:i] link] image:[[self.elements objectAtIndex:i] imageName]];
+			[self drawString:element.text withFont:font atPoint:_currentPosition inRect:rect recursive:YES style:element.style withLink:element.link image:element.imageName];
 		}
 		
-		if ([[self.elements objectAtIndex:i] style] == SMFancyTextElementStyleBlockQuote) {
+		if (element.style == SMFancyTextElementStyleBlockQuote) {
 			CGContextFillRect(graphicsContext, CGRectMake(0, _currentPosition.y + 20, rect.size.width, 2));
 		}
 	}
 }
 
-- (void)drawString:(NSString *)string withFont:(UIFont *)font atPoint:(CGPoint)point inRect:(CGRect)rect recursive:(BOOL)recursive style:(SMFancyTextElementStyle)style withLink:(NSString *)link image:(NSString *)image {
+- (void)drawString:(NSString *)string
+		  withFont:(UIFont *)font
+		   atPoint:(CGPoint)point
+			inRect:(CGRect)rect
+		 recursive:(BOOL)recursive
+			 style:(SMFancyTextElementStyle)style
+		  withLink:(NSString *)link
+			 image:(NSString *)image {
 	
 	if (point.x == 0) {
 		string = [self removeLeadingWhiteSpaceFromString:string];
@@ -120,10 +130,11 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 	CGRect theRect = CGRectMake(_currentPosition.x, _currentPosition.y, size.width, size.height);
 		
 	if (link != nil || image != nil) {
-		CGContextRef graphicsContext = UIGraphicsGetCurrentContext();
+		CGContextRef context = UIGraphicsGetCurrentContext();
 		
 		if (style == SMFancyTextElementStyleLink) {
 			if ([_delegate respondsToSelector:@selector(fancyText:linkPressed:)]) {
+				
 				UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
 				[button setFrame:theRect];
 				[button setTitle:link forState:UIControlStateNormal];
@@ -132,16 +143,20 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 				[button addTarget:self action:@selector(linkPressed:) forControlEvents:UIControlEventTouchDown];
 				[self addSubview:button];
 				
-				CGContextSetFillColorWithColor(graphicsContext, [[UIColor colorWithRed:65.0/255.0 green:123.0/255.0 blue:192.0/255.0 alpha:1] CGColor]);
-				CGContextFillRect(graphicsContext, CGRectMake(_currentPosition.x, _currentPosition.y + (theRect.size.height - 2), theRect.size.width, 1));
+				CGContextSetFillColorWithColor(context, [[UIColor colorWithRed:SMLinkRed / 255.0 green:SMLinkGreen / 255.0 blue:SMLinkBlue / 255.0 alpha:1] CGColor]);
+				CGContextFillRect(context, CGRectMake(_currentPosition.x, _currentPosition.y + (theRect.size.height - 2), theRect.size.width, 1));
 				[string drawInRect:theRect withFont:font];
-				CGContextSetFillColorWithColor(graphicsContext, [self.textColor CGColor]);
+				CGContextSetFillColorWithColor(context, [self.textColor CGColor]);
+				
 			}
 		} else if (style == SMFancyTextElementStyleImage) {
+			
 			UIImage *theImage = [UIImage imageNamed:image];
 			[theImage drawInRect:CGRectMake((self.frame.size.width / 2) - (theImage.size.width / 2), _currentPosition.y, theImage.size.width, theImage.size.height)];
 			_currentPosition.y += theImage.size.height;
+			
 		} else if (style == SMFancyTextElementStyleImageLink) {
+			
 			UIImage *theImage = [UIImage imageNamed:image];
 			
 			CGRect imageFrame = CGRectMake((self.frame.size.width / 2) - (theImage.size.width / 2), _currentPosition.y, theImage.size.width, theImage.size.height);
@@ -155,6 +170,7 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 			[self addSubview:button];
 			
 			_currentPosition.y += theImage.size.height;
+			
 		}
 	} else {
 		[string drawInRect:theRect withFont:font];
@@ -176,23 +192,28 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 	
 	NSData *data = [[NSString stringWithFormat:@"<SMFancyText>%@</SMFancyText>", [newText stringByReplacingOccurrencesOfString:@"\n" withString:@""]] dataUsingEncoding:NSUTF8StringEncoding];
 
-	_context = htmlCreatePushParserCtxt(&simpleSAXHandlerStruct, self, NULL, 0, NULL, XML_CHAR_ENCODING_UTF8);
-	htmlParseChunk(_context, (const char *)[data bytes], [data length], 0);
-	htmlFreeParserCtxt(_context);
-	_context = NULL;
+	htmlParserCtxtPtr context = htmlCreatePushParserCtxt(&simpleSAXHandlerStruct, self, NULL, 0, NULL, XML_CHAR_ENCODING_UTF8);
+	htmlParseChunk(context, (const char *)[data bytes], [data length], 0);
+	htmlFreeParserCtxt(context);
+	context = NULL;
 }
 
 - (NSString *)removeLeadingWhiteSpaceFromString:(NSString *)string {
+	if (!string) return nil;
 
-	if (string == nil) {
-		return nil;
-	}
-	
 	NSMutableString *mutableString = [NSMutableString stringWithString:string];
 
-	[mutableString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+	NSInteger whitespaceCount = 0;
 
-	return [NSString stringWithString:mutableString];
+	for (NSInteger i = 0; i < string.length; ++i) {
+		if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[mutableString characterAtIndex:i]]) {
+			whitespaceCount = i;
+		} else {
+			break;
+		}
+	}
+
+	return [string substringFromIndex:whitespaceCount];
 }
 
 - (void)dealloc {
@@ -209,9 +230,7 @@ static xmlSAXHandler simpleSAXHandlerStruct;
 }
 
 - (void)saveCurrentElement {
-	if (self.currentElement == nil) {
-		return;
-	}
+	if (!self.currentElement) return;
 	[self.elements addObject:self.currentElement];
 	self.currentElement = nil;
 }
@@ -226,7 +245,7 @@ void startElement(void *ctx, const xmlChar *name, const xmlChar **atts) {
 		textView.currentElement.style = SMFancyTextElementStyleImageLink;
 		
 		for (NSUInteger i = 0; i < sizeof(atts); ++i) {
-			if (!strcmp((char *)atts[i], "src")) {
+			if (!xmlStrcmp(atts[i], (unsigned char *)"src")) {
 				textView.currentElement.imageName = [NSString stringWithCString:(const char *) atts[i+1] encoding:NSUTF8StringEncoding];
 				break;
 			}
@@ -241,42 +260,42 @@ void startElement(void *ctx, const xmlChar *name, const xmlChar **atts) {
 	// first, insert newlines/paragraphs where needed
 	
 	if (!strcmp((char *)name, "blockquote") || !strcmp((char *)name, "img")) {
-		SMFancyTextElement *element = [[[SMFancyTextElement alloc] init] autorelease];
-		element.style = SMFancyTextElementStyleNewLine;
-		textView.currentElement = element;
+		textView.currentElement = [SMFancyTextElement textElementWithStyle:SMFancyTextElementStyleNewLine];
 		[textView saveCurrentElement];
 	}
 	
-	SMFancyTextElement *element = [[[SMFancyTextElement alloc] init] autorelease];
+	SMFancyTextElement *element = [SMFancyTextElement textElement];
 
-	if (!strcmp((char *)name, "strong") || !strcmp((char *)name, "b")) {
+	if (!xmlStrcmp(name, (unsigned char *)"strong") ||
+		!xmlStrcmp(name, (unsigned char *)"b")) {
 		element.style = SMFancyTextElementStyleBold;
-	} else if (!strcmp((char *)name, "em") || !strcmp((char *)name, "i")) {
+	} else if (!xmlStrcmp(name, (unsigned char *)"em") ||
+			   !xmlStrcmp(name, (unsigned char *)"i")) {
 		element.style = SMFancyTextElementStyleItalic;
-	} else if (!strcmp((char *)name, "li")) {
+	} else if (!xmlStrcmp(name, (unsigned char *)"li")) {
 		element.style = SMFancyTextElementStyleListItem;
-	} else if (!strcmp((char *)name, "ul")) {
+	} else if (!xmlStrcmp(name, (unsigned char *)"ul")) {
 		element.style = SMFancyTextElementStyleNewLine;
-	} else if (!strcmp((char *)name, "blockquote")) {
+	} else if (!xmlStrcmp(name, (unsigned char *)"blockquote")) {
 		element.style = SMFancyTextElementStyleBlockQuote;
-	} else if (!strcmp((char *)name, "a")) {
+	} else if (!xmlStrcmp(name, (unsigned char *)"a")) {
 		element.style = SMFancyTextElementStyleLink;
+		
 		for (NSUInteger i = 0; i < sizeof(atts); ++i) {
-			if (!strcmp((char *)atts[i], "href")) {
+			if (!xmlStrcmp(atts[i], (unsigned char *)"href")) {
 				element.link = [NSString stringWithCString:(const char *) atts[i+1] encoding:NSUTF8StringEncoding];
 				break;
 			}
 		}
-	} else if (!strcmp((char *)name, "img")) {
+	} else if (!xmlStrcmp(name, (unsigned char *)"img")) {
 		element.style = SMFancyTextElementStyleImage;
+		
 		for (NSUInteger i = 0; i < sizeof(atts); ++i) {
-			if (!strcmp((char *)atts[i], "src")) {
+			if (!xmlStrcmp(atts[i], (unsigned char *)"src")) {
 				element.link = [NSString stringWithCString:(const char *) atts[i+1] encoding:NSUTF8StringEncoding];
 				break;
 			}
 		}
-	} else {
-		element.style = SMFancyTextElementStyleNormal;
 	}
 		
 	textView.currentElement = element;
@@ -287,15 +306,13 @@ void endElement(void *ctx, const xmlChar *name) {
 	SMFancyText *textView = (SMFancyText *) ctx;
 	[textView saveCurrentElement];
 	
-	if (!strcmp((char *) name, "p") || !strcmp((char *) name, "li") || !strcmp((char *) name, "ul")) {
-		SMFancyTextElement *element = [[[SMFancyTextElement alloc] init] autorelease];
-		element.style = SMFancyTextElementStyleNewLine;
-		textView.currentElement = element;
+	if (!xmlStrcmp(name, (unsigned char *)"p") ||
+		!xmlStrcmp(name, (unsigned char *)"li") ||
+		!xmlStrcmp(name, (unsigned char *)"ul")) {
+		textView.currentElement = [SMFancyTextElement textElementWithStyle:SMFancyTextElementStyleNewLine];
 		[textView saveCurrentElement];
-	} else if (!strcmp((char *) name, "blockquote")) {
-		SMFancyTextElement *element = [[[SMFancyTextElement alloc] init] autorelease];
-		element.style = SMFancyTextElementStyleParagraphBreak;
-		textView.currentElement = element;
+	} else if (!xmlStrcmp(name, (unsigned char *)"blockquote")) {
+		textView.currentElement = [SMFancyTextElement textElementWithStyle:SMFancyTextElementStyleParagraphBreak];
 		[textView saveCurrentElement];
 	}
 }
@@ -304,21 +321,17 @@ void charactersFound(void *ctx, const xmlChar *ch, int len) {
 	
 	SMFancyText *textView = (SMFancyText *) ctx;
 	
-	if (textView.currentElement == nil) {
-		SMFancyTextElement *element = [[[SMFancyTextElement alloc] init] autorelease];
-		element.style = SMFancyTextElementStyleNormal;
-		textView.currentElement = element;
-	}
+	if (!textView.currentElement) textView.currentElement = [SMFancyTextElement textElement];
 	
 	if (textView.currentElement.style == SMFancyTextElementStyleListItem) {
-		textView.currentElement.text = [NSString stringWithFormat:@"%@ %@", HTMLBullet, [NSString stringWithCString:(const char *) ch encoding:NSUTF8StringEncoding]];
+		textView.currentElement.text = [NSString stringWithFormat:@"%@ %@", SMHTMLBullet, [NSString stringWithCString:(const char *) ch encoding:NSUTF8StringEncoding]];
 	} else {
 		textView.currentElement.text = [NSString stringWithCString:(const char *) ch encoding:NSUTF8StringEncoding];
 	}
 }
 
 void endDocument(void *ctx) {
-	SMFancyText *textView = (SMFancyText *) ctx;
+	SMFancyText *textView = (SMFancyText *)ctx;
 	[textView setNeedsDisplay];
 }
 

--- a/Classes/SMFancyTextElement.h
+++ b/Classes/SMFancyTextElement.h
@@ -16,6 +16,9 @@ typedef NS_ENUM(NSUInteger, SMFancyTextElementStyle) {
 
 @interface SMFancyTextElement : NSObject
 
++ (instancetype)textElement;
++ (instancetype)textElementWithStyle:(SMFancyTextElementStyle)style;
+
 @property (nonatomic, retain) NSString *text;
 @property SMFancyTextElementStyle style;
 @property (nonatomic, retain) NSString *link;

--- a/Classes/SMFancyTextElement.m
+++ b/Classes/SMFancyTextElement.m
@@ -2,6 +2,18 @@
 
 @implementation SMFancyTextElement
 
++ (instancetype)textElement {
+	return [self textElementWithStyle:SMFancyTextElementStyleNormal];
+}
+
++ (instancetype)textElementWithStyle:(SMFancyTextElementStyle)style {
+	SMFancyTextElement *element = [[[SMFancyTextElement alloc] init] autorelease];
+
+	element.style = style;
+
+	return element;
+}
+
 - (NSString *)description {
 	return [NSString stringWithFormat:@"SMFancyTextElement ::  %@ - %d", _text, _style];
 }


### PR DESCRIPTION
Added convenience constructors to SMFancyTextElement class.
Removed _context ivar from SMFancyText.
Converted some magic numbers into consts.
Replaced checks for nil equality with not operator.
Replaced for loop in SMFancyText drawRect: with iterator.
Leading whitespace removal works again (with faster/more accurate
algorithm).
Replaced calls to strcmp() with xmlStrcmp().
